### PR TITLE
Fix import in utils module

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -7,9 +7,14 @@ import time
 from PIL import Image
 
 from src.utils.LinkableValue import linkableValueDumpsToJSON
-from src.utils.constants import THAUM_CONTROLS_CONFIG_PATH, THAUM_ASPECT_RECIPES_CONFIG_PATH, THAUM_VERSION_CONFIG_PATH, \
-    DELAY_BETWEEN_EVENTS, DELAY_BETWEEN_RENDER
-from utils.constants import THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH
+from src.utils.constants import (
+    THAUM_CONTROLS_CONFIG_PATH,
+    THAUM_ASPECT_RECIPES_CONFIG_PATH,
+    THAUM_VERSION_CONFIG_PATH,
+    DELAY_BETWEEN_EVENTS,
+    DELAY_BETWEEN_RENDER,
+    THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH,
+)
 
 
 def distance(x1, y1, x2, y2):


### PR DESCRIPTION
## Summary
- correct import path for THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH
- run python bytecode compilation

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall -q src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe4e682948324b4e1cbf8ff699a7e