### PR TITLE
Fix OverlayUI FPS constant

### DIFF
--- a/src/UI/OverlayUI.py
+++ b/src/UI/OverlayUI.py
@@ -13,8 +13,8 @@ from PyQt5.QtWidgets import QApplication, QDesktopWidget, QMainWindow
 
 from src.UI.primitives import Point, Text, UIPrimitive
 from src.utils.LinkableValue import editLinkableValue
+from src.utils.constants import FPS
 
-FPS = 60
 FRAME_TIME = int(1000 / FPS)
 
 


### PR DESCRIPTION
## Summary
- remove local FPS definition in `OverlayUI`
- use `FPS` from `src.utils.constants`
- compute `FRAME_TIME` from imported FPS

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fee06f8288324a8f2007cb889b111