### PR TITLE
Implement reverse arithmetic for LinkableValue

### DIFF
--- a/src/utils/LinkableValue.py
+++ b/src/utils/LinkableValue.py
@@ -26,6 +26,21 @@ class LinkableValue:
             return self.val * other.val
         return self.val * other
 
+    def __radd__(self, other):
+        if isinstance(other, LinkableValue):
+            return other.val + self.val
+        return other + self.val
+
+    def __rsub__(self, other):
+        if isinstance(other, LinkableValue):
+            return other.val - self.val
+        return other - self.val
+
+    def __rmul__(self, other):
+        if isinstance(other, LinkableValue):
+            return other.val * self.val
+        return other * self.val
+
     def __truediv__(self, other):
         if isinstance(other, LinkableValue):
             return self.val / other.val


### PR DESCRIPTION
## Summary
- add `__radd__`, `__rsub__` and `__rmul__` to `LinkableValue`
- allow math between numeric types and `LinkableValue` in both directions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff27ad2748324abf522646e4ae37c