### PR TITLE
Fix logger import

### DIFF
--- a/src/UI/OverlayUI.py
+++ b/src/UI/OverlayUI.py
@@ -3,7 +3,7 @@ import sys
 import traceback
 from enum import Enum
 from typing import Callable, Any
-from venv import logger
+logger = logging.getLogger(__name__)
 
 import keyboard
 from PyQt5 import QtGui


### PR DESCRIPTION
## Summary
- drop unused `from venv import logger`
- create a module level logger with `logging.getLogger(__name__)`

## Testing
- `python -m py_compile src/UI/OverlayUI.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683ff27fced88324b2b8990aa84b18af