### PR TITLE
Fix missing addon recipes handling

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -171,8 +171,13 @@ def loadRecipesForSelectedVersion() -> dict[str, list[str, str]] | None:
         logging.error(f"Selected unknown version: {selectedVersion}")
         return None
     addonsRecipes = readJSONConfig(THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH)
-    for addonRecipes in addonsRecipes.values():
-        totalRecipes |= addonRecipes
+    if addonsRecipes:
+        for addonRecipes in addonsRecipes.values():
+            totalRecipes |= addonRecipes
+    else:
+        logging.debug(
+            f"No addon recipes found at {THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH}"
+        )
     return totalRecipes
 
 


### PR DESCRIPTION
## Summary
- avoid crash when addon recipe JSON is absent

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847dca6bd94832aa546df07aea566f1