### PR TITLE
Improve aspect detection robustness

### DIFF
--- a/src/controllers/ThaumInteractor.py
+++ b/src/controllers/ThaumInteractor.py
@@ -531,6 +531,13 @@ class ThaumInteractor:
             def exitWithSort():
                 self.UI.removeObject(debugHighlightingRect)
 
+                # Leave only unique aspects by UID to avoid duplicated references
+                unique_aspects: dict[int, Aspect] = {}
+                for aspect in self.availableAspects:
+                    if aspect.uid not in unique_aspects:
+                        unique_aspects[aspect.uid] = aspect
+                self.availableAspects = list(unique_aspects.values())
+
                 # Sort found aspects
                 self.availableAspects.sort(key=lambda a: a.uid)
                 logging.info("All detected available aspects was sorted")
@@ -574,8 +581,13 @@ class ThaumInteractor:
                     try:
                         aspect = self.getAspectByName(prediction.predictionName)
                         aspect_count = count_predictions.get(prediction.predictionName)
-                        if aspect.count is None:  # count initialization
-                            aspect.count = aspect_count or 0
+                        if aspect_count is None:
+                            logging.debug(
+                                "Skip updating count for %s: prediction returned None",
+                                prediction.predictionName,
+                            )
+                        elif aspect.count is None:  # count initialization
+                            aspect.count = aspect_count
                         else:
                             # If predictions differ we take minimal
                             # because it's better to underestimate than to overestimate aspects count

--- a/src/logic/Neurolink.py
+++ b/src/logic/Neurolink.py
@@ -12,17 +12,9 @@ class _NeurolinkClass:
     field_aspects_model: OnnxObjectDetection
     inventory_aspects_model: OnnxObjectDetection
 
-    # Make it singleton
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(_NeurolinkClass, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
-
     def __init__(self):
         # Detect available ORT providers and intersect with desired ones
-        available_providers = set(ort.get_available_providers())
+        available_providers = ort.get_available_providers()
         desired_providers = [p for p in constants.ORT_PROVIDERS if p in available_providers]
         selected_providers = desired_providers or list(available_providers)
         

--- a/src/logic/digit_recognition.py
+++ b/src/logic/digit_recognition.py
@@ -12,10 +12,10 @@ def is_aspect(prediction: ObjectPrediction) -> bool:
 
 def prediction_inside_prediction(pred_inner: ObjectPrediction, pred_outer: ObjectPrediction) -> bool:
     """True, если pred_inner находится внутри pred_outer"""
-    x_min = pred_outer.x - pred_outer.width // 2
-    x_max = pred_outer.x + pred_outer.width // 2
-    y_min = pred_outer.y - pred_outer.height // 2
-    y_max = pred_outer.y + pred_outer.height // 2
+    x_min = pred_outer.x - pred_outer.width / 2
+    x_max = pred_outer.x + pred_outer.width / 2
+    y_min = pred_outer.y - pred_outer.height / 2
+    y_max = pred_outer.y + pred_outer.height / 2
     return x_min <= pred_inner.x <= x_max and y_min <= pred_inner.y <= y_max
 
 


### PR DESCRIPTION
## Summary
- avoid truncating bounding boxes when checking if digits fall inside an aspect detection
- keep previously recognised aspect counts when the counter model returns no prediction
- deduplicate inventory aspects and simplify ONNX Runtime provider selection ordering

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d5933942108324a6fd198a7db94582