### PR TITLE
Fix import namespace for constants in utils

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -9,7 +9,7 @@ from PIL import Image
 from src.utils.LinkableValue import linkableValueDumpsToJSON
 from src.utils.constants import THAUM_CONTROLS_CONFIG_PATH, THAUM_ASPECT_RECIPES_CONFIG_PATH, THAUM_VERSION_CONFIG_PATH, \
     DELAY_BETWEEN_EVENTS, DELAY_BETWEEN_RENDER
-from utils.constants import THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH
+from src.utils.constants import THAUM_ADDONS_ASPECT_RECIPES_CONFIG_PATH
 
 
 def distance(x1, y1, x2, y2):


### PR DESCRIPTION
## Summary
- update utils constants import to use src.utils namespace for consistency

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eb5de2d048324929997e2c1b759d4)